### PR TITLE
Fix layout issue

### DIFF
--- a/src/components/Layout/CardLayout.svelte
+++ b/src/components/Layout/CardLayout.svelte
@@ -52,7 +52,7 @@ limitations under the License. -->
     grid-template-rows: repeat(3, 1fr);
     grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
     grid-gap: 20px;
-    height: 100%;
+    min-height: 100%;
   }
 
   .icon {


### PR DESCRIPTION
The natural height of the container could be larger than 100% of the viewport height, causing it to overflow and overlap with the footer text. This change allows the container to grow to its natural height if needed, and push the footer below it to avoid the overlap.

Before:

![image](https://user-images.githubusercontent.com/1120896/83292747-a014e600-a1b8-11ea-91e8-146d2e06eca6.png)

After:

![image](https://user-images.githubusercontent.com/1120896/83292728-95f2e780-a1b8-11ea-9650-4bfef188dcd1.png)

I'm not familiar with svelte though so some other building seems necessary to push this change to each individual tool-specific CSS.
